### PR TITLE
修复了因处于 Steam 存档位置的无效存档崩溃的 bug。

### DIFF
--- a/app/editor/locator.py
+++ b/app/editor/locator.py
@@ -53,7 +53,9 @@ class _Locator:
             save_file = os.path.join(saves_path, account, '787480', 'remote', 'systemdata')
             if os.path.exists(save_file):
                 if os.path.getsize(save_file) != STEAM_SAVE_LENGTH:
-                    raise InvaildSaveLengthError(save_file, STEAM_SAVE_LENGTH, os.path.getsize(save_file))
+                    # raise InvaildSaveLengthError(save_file, STEAM_SAVE_LENGTH, os.path.getsize(save_file))
+                    logger.warning(f'Save file "{save_file}" length is not {STEAM_SAVE_LENGTH}, skipped.')
+                    continue
                 save_files.append((account, save_file))
         return save_files
     

--- a/app/native_ui/implement.py
+++ b/app/native_ui/implement.py
@@ -18,7 +18,7 @@ from .form import FrameMain, FrameSlotManager
 from app.structs.steam import PresideData, GameData
 from app.structs.xbox import PresideDataXbox
 from app.editor.slot_editor import SlotEditor, IncompatibleSlotError
-from app.editor.save_editor import NoGameFoundError, SaveEditor, NoOpenSaveFileError, SaveType
+from app.editor.save_editor import NoGameFoundError, SaveEditor, NoOpenSaveFileError, SaveType, logger
 from app.unpack.decrypt import decrypt_file, encrypt_file, decrypt_folder, encrypt_folder
 from app.exceptions import GameFileMissingError
 
@@ -119,7 +119,12 @@ class FrameMainImpl(FrameMain):
             if fileDialog.ShowModal() == wx.ID_CANCEL:
                 return
             path = fileDialog.GetPath()
-            self.editor.load(path)
+            try:
+                self.editor.load(path)
+            except ValueError:
+                logger.warning(f'Invalid save file "{path}"')
+                wx.MessageBox(_(u'无效的存档文件。'), _(u'错误'), wx.OK | wx.ICON_ERROR)
+                return
             self.load_basic_ui()
             
     def mi_open_steam_on_select(self, event):


### PR DESCRIPTION
如题 #3 ，处于 Steam 存档位置的无效存档会导致在程序开始时抛出未捕捉的 `InvaildSaveLengthError` 异常导致程序闪退，本 PR 将抛出异常改为跳过此存档。
另外，本 PR 捕捉了“文件>打开...”按钮，选择无效的文件抛出的 `ValueError` 异常，改为提示 `无效的存档文件`。